### PR TITLE
github.action_path not available if not set

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,4 +52,4 @@ runs:
         REGISTRY_URL: ${{ inputs.registry_url }}
         ACCESS_TOKEN: ${{ inputs.access_token }}
         SERVICE_ACCOUNT: ${{ inputs.user_name }}
-        ACTION_PATH: ${{ inputs.action_path }}
+        ACTION_PATH: ${{ inputs.action_path || github.action_path }}


### PR DESCRIPTION
- The default was not being used when not provided
- Theory is that it is not available when inputs parsed
- Try to set it if it when job is wrong